### PR TITLE
Fix pyproject.toml to include all project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,22 @@ dependencies = [
     "mkdocs",
     "mkdocs-material",
     "mkdocstrings[python]",
+    "torch",
+    "pandas",
+    "graphviz",
+    "pygraphviz",
+    "tqdm",
+    "scipy",
 ]
+
+[project.optional-dependencies]
+dev = ["black", "coverage", "jupyterlab", "matplotlib", "numpy", "pytest", "seaborn", "tensorboard", "torchvision"]
+monitoring = ["tensorboard"]
 
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
 ]
+
+[tool.setuptools]
+packages = ["flox"]


### PR DESCRIPTION
- [x] all default dependencies are included
- [x] all dev dependencies (i.e., for tests, jupyter notebooks, etc., included)