### PR TITLE
Refactor ProxystoreTransfer class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy",
     "pandas",
     "parsl",
-    "proxystore",
+    "proxystore>=0.7.1",
     "scipy",
     "scikit-learn",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
+    "parsl",
     "proxystore",
     "scipy",
     "scikit-learn",
@@ -73,16 +74,31 @@ docs = [
     "mkdocstrings-python",
 ]
 
+[tool.coverage.run]
+omit = ["*/_remote_module_non_scriptable.py"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+exclude_also = [
+    # a more strict default pragma
+    "\\# pragma: no cover\\b",
+    # allow defensive code
+    "^\\s*raise AssertionError\\b",
+    "^\\s*raise NotImplementedError\\b",
+    "^\\s*return NotImplemented\\b",
+    "^\\s*raise$",
+    # typing-related code
+    "^\\s*if (False|TYPE_CHECKING):",
+    ": \\.\\.\\.(\\s*#.*)?$",
+    "^ +\\.\\.\\.$",
+]
+
 [tool.mypy]
 plugins = [
-    "numpy.typing.mypy_plugin"
+    "numpy.typing.mypy_plugin",
+    "proxystore.mypy_plugin",
 ]
-
-[tool.pytest.ini_options]
-addopts = [
-    "--import-mode=importlib",
-]
-
 
 [tool.setuptools.packages.find]
 include = ["flight*"]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ allowlist_externals = coverage
 commands =
     coverage erase
     coverage run -m pytest tests {posargs}
-    coverage report
+    coverage report --ignore-errors
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
Fixes #30 
- Reuse stateful `Store` object between calls to `.proxy()`
- Do not reinitialize `Store` if already created in that process
- Improve typing on `.proxy()`
- Customize pickle behavior to ignore stateful attributes
- Add `evict` setting for proxies
- Add note on supporting customized serializers in future
- Bump ProxyStore to 0.7.1 and later (should be okay now since flight is Python 3.11 and later and globus compute supports pydantic 2 now)

I also fixed a couple things that prevented me from running the test cases.
- `--import-mode=importlib` has dangerous side-effects so I removed it. I suspect this was added because certain modules in `tests/` or `testing/` could not be imported, but that's usually because of missing `__init__.py` (which I found and added one).
- PyTorch distributed writes `/tmp/tmpd8vgpvq4/_remote_module_non_scriptable.py` which coverage is aware of but cannot parse, so I added `--ignore-errors` to the `coverage report` command and that specific file to `omit` for coveralls.
- `parsl` was missing from the dependencies and is required to run the tests.
- Added some handy exclusions for coverage.